### PR TITLE
docs: require assignee and label before oldest-PR merge

### DIFF
--- a/.cursor/rules/prs.mdc
+++ b/.cursor/rules/prs.mdc
@@ -8,5 +8,6 @@ alwaysApply: true
 - Always **squash merge** PRs into the default branch: `gh pr merge <N> --squash`.
 - Do **not** use `--merge` or `--rebase` unless a maintainer explicitly requests an exception.
 - Prefer an English Conventional Commits subject for the squash commit message.
+- Before merge (including `oldest-pr-merge`): assign **`cursoragent`** if possible, else **`jimmyandrade`**, and ensure **at least one meaningful label**. Do not merge without both.
 
-See `CONTRIBUTING.md` and `AGENTS.md`.
+See `CONTRIBUTING.md`, `AGENTS.md`, and `.cursor/skills/oldest-pr-merge/`.

--- a/.cursor/skills/oldest-pr-merge/SKILL.md
+++ b/.cursor/skills/oldest-pr-merge/SKILL.md
@@ -18,13 +18,14 @@ Copy and track this checklist:
 ```
 Oldest PR progress:
 - [ ] 1. Select and analyze oldest open PR
+- [ ] 1b. Ensure assignee + at least one meaningful label (hard gate)
 - [ ] 2. Check test coverage for the changes
 - [ ] 3. Add missing tests on the same PR branch
 - [ ] 4. Resolve all review comments (incl. Copilot) in a loop
 - [ ] 5. Run tests and check for regressions
 - [ ] 6. Fix regressions if any
 - [ ] 7. Record work in TROUBLESHOOTING.md / AGENTS.md (and ADR if needed)
-- [ ] 8. Merge only when comments done, tests green, CI green
+- [ ] 8. Merge only when comments done, tests green, CI green, assignee + label set
 - [ ] 9. Close related issue(s) with a summary comment
 - [ ] 10. Final uncommitted-diff sweep and commit(s)
 ```
@@ -32,20 +33,66 @@ Oldest PR progress:
 ## 1. Pick the oldest open PR and analyze it
 
 ```bash
-gh pr list --state open --limit 100 --json number,title,createdAt,author,url,headRefName,baseRefName,labels,body \
+gh pr list --state open --limit 100 --json number,title,createdAt,author,url,headRefName,baseRefName,labels,assignees,body \
   --jq 'sort_by(.createdAt) | .[0]'
 ```
 
 Then:
 
 ```bash
-gh pr view <N> --json title,body,files,commits,statusCheckRollup,reviewDecision,comments,reviews
+gh pr view <N> --json title,body,files,commits,statusCheckRollup,reviewDecision,comments,reviews,assignees,labels
 gh pr diff <N>
 ```
 
 Checkout the PR branch (`gh pr checkout <N>`). Summarize intent, risk, and touched areas before editing.
 
 If there is no open PR, stop and report that.
+
+## 1b. Assignees and labels (mandatory before merge)
+
+As soon as you start processing the PR (right after checkout / analysis), **and again immediately before merge**, ensure metadata is set. **Never merge** a PR that is missing either requirement.
+
+### Assignees
+
+Prefer **`cursoragent`**; if that user is not assignable on the repo, fall back to **`jimmyandrade`**.
+
+```bash
+# Prefer cursoragent; fall back to jimmyandrade if not assignable
+if gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/assignees/cursoragent" --silent 2>/dev/null; then
+  gh pr edit <N> --add-assignee cursoragent
+else
+  gh pr edit <N> --add-assignee jimmyandrade
+fi
+
+# Verify at least one required assignee is present
+gh pr view <N> --json assignees --jq '
+  [.assignees[].login] as $a
+  | if ($a | index("cursoragent") or index("jimmyandrade")) then "ok" else error("missing required assignee") end
+'
+```
+
+If neither user can be assigned, **stop and escalate** — do not merge.
+
+### Labels
+
+Ensure **at least one meaningful label** from the repo’s existing labels (create a new label only when none fit and the name is clearly useful). Prefer:
+
+| PR kind | Example labels |
+| --- | --- |
+| Renovate / dependency bumps | `dependencies`, `renovate` |
+| Docs / skills / AGENTS | `documentation` |
+| Bug fix | `bug` |
+| Feature / product change | `enhancement` |
+| CI / workflows | add or reuse a CI-related label if present; otherwise `dependencies` only when that fits |
+
+```bash
+gh label list --limit 100
+gh pr view <N> --json labels --jq '.labels | length'
+# If zero labels, add one that fits, e.g.:
+gh pr edit <N> --add-label "dependencies"
+```
+
+A label is **meaningful** when it describes the PR’s nature (deps, docs, bug, enhancement, CI, etc.). Do not invent placeholder labels like `todo` unless that is the real status.
 
 ## 2. Verify tests cover the changes
 
@@ -103,8 +150,13 @@ Merge **only if all** are true:
 - All review comments answered and resolved
 - No known test regressions locally
 - PR CI pipeline is green (or only waived checks the user explicitly approved)
+- **Assignee set**: `cursoragent` (preferred) or `jimmyandrade` (fallback) is among assignees
+- **At least one meaningful label** is present
+
+Re-check metadata right before merge (see §1b and [gh-recipes.md](gh-recipes.md)). If assignee or label is missing, set them first — **do not merge without both**.
 
 ```bash
+gh pr view <N> --json assignees,labels --jq '{assignees:[.assignees[].login],labels:[.labels[].name]}'
 gh pr checks <N>
 gh pr merge <N> --squash
 ```
@@ -153,6 +205,7 @@ Stop and ask the user when:
 - Changes require product/architecture choice beyond ADRs
 - CI failures need secrets/network access you do not have
 - Merge requires admin bypass or force push
+- Neither `cursoragent` nor `jimmyandrade` can be assigned (assignee hard gate)
 
 ## Additional resources
 

--- a/.cursor/skills/oldest-pr-merge/SKILL.md
+++ b/.cursor/skills/oldest-pr-merge/SKILL.md
@@ -118,7 +118,7 @@ fi
 # Verify at least one required assignee is present
 gh pr view <N> --json assignees --jq '
   [.assignees[].login] as $a
-  | if ($a | index("cursoragent") or index("jimmyandrade")) then "ok" else error("missing required assignee") end
+  | if (($a | index("cursoragent")) or ($a | index("jimmyandrade"))) then "ok" else error("missing required assignee") end
 '
 ```
 

--- a/.cursor/skills/oldest-pr-merge/SKILL.md
+++ b/.cursor/skills/oldest-pr-merge/SKILL.md
@@ -18,6 +18,7 @@ Copy and track this checklist:
 ```
 Oldest PR progress:
 - [ ] 1. Select and analyze oldest open PR
+- [ ] 1a. If already on main (Dependabot/Renovate), request bot rebase — do not close
 - [ ] 1b. Ensure assignee + at least one meaningful label (hard gate)
 - [ ] 2. Check test coverage for the changes
 - [ ] 3. Add missing tests on the same PR branch
@@ -29,6 +30,14 @@ Oldest PR progress:
 - [ ] 9. Close related issue(s) with a summary comment
 - [ ] 10. Final uncommitted-diff sweep and commit(s)
 ```
+
+## Continuous backlog drain
+
+When the user asks to run `oldest-pr-merge`, clear the backlog, or says to keep going to the next PR:
+
+1. After finishing one PR (merge, or Dependabot/Renovate has closed it after rebase), **immediately** select the new oldest open PR and repeat the full checklist.
+2. **Do not ask** whether to continue between PRs.
+3. Stop only on the [Stop / escalate conditions](#stop--escalate-conditions), when there are no open PRs left, or when the user explicitly cancels.
 
 ## 1. Pick the oldest open PR and analyze it
 
@@ -47,6 +56,48 @@ gh pr diff <N>
 Checkout the PR branch (`gh pr checkout <N>`). Summarize intent, risk, and touched areas before editing.
 
 If there is no open PR, stop and report that.
+
+## 1a. Already on `main` (Dependabot / Renovate) — request rebase, never self-close
+
+If analysis shows the PR is **redundant with `main`** (examples below), **do not** `gh pr close` or abandon the PR yourself.
+
+Treat as already-on-main when any of these hold:
+
+- The titled dependency version is already present on `main`’s `package.json` / lockfile
+- `git diff origin/main...HEAD` (or the PR merge diff) has no remaining meaningful package change
+- A squash merge would be empty / no-op relative to current `main`
+
+### Dependabot
+
+1. Comment on the PR **mentioning Dependabot** and requesting a rebase (English):
+
+```bash
+gh pr comment <N> --body "$(cat <<'EOF'
+@dependabot rebase
+
+This looks redundant with current `main` (dependency already present or empty merge). Please rebase so Dependabot can close or refresh the PR itself.
+EOF
+)"
+```
+
+2. **Wait** for Dependabot to rebase and for CI to run (`gh pr checks <N>` / `gh run watch` as needed).
+3. **Let Dependabot close** the PR if the bump is obsolete after rebase. Do not close it manually.
+4. If after rebase the PR still has a real bump, continue the normal merge checklist (§1b onward).
+
+### Renovate
+
+Same policy for Renovate-authored PRs: do **not** self-close when already on `main`. Request a rebase and wait for the bot:
+
+```bash
+gh pr comment <N> --body "$(cat <<'EOF'
+@renovate rebase
+
+This looks redundant with current `main`. Please rebase so Renovate can close or refresh the PR itself.
+EOF
+)"
+```
+
+See [gh-recipes.md](gh-recipes.md) for the snippet. After the bot closes (or the PR becomes mergeable again), continue the backlog drain.
 
 ## 1b. Assignees and labels (mandatory before merge)
 
@@ -206,6 +257,7 @@ Stop and ask the user when:
 - CI failures need secrets/network access you do not have
 - Merge requires admin bypass or force push
 - Neither `cursoragent` nor `jimmyandrade` can be assigned (assignee hard gate)
+- Dependabot/Renovate was asked to rebase an already-on-main PR but does not respond within a long wait and the PR stays open with no clear next step (do not self-close; escalate)
 
 ## Additional resources
 

--- a/.cursor/skills/oldest-pr-merge/gh-recipes.md
+++ b/.cursor/skills/oldest-pr-merge/gh-recipes.md
@@ -52,6 +52,32 @@ gh pr edit <N> --add-label "enhancement"    # features
 
 Never merge a PR with zero labels.
 
+## Already on `main` — Dependabot / Renovate rebase (do not self-close)
+
+When the PR’s bump is already on `main` (or the merge would be empty), **never** `gh pr close`. Ask the bot to rebase and wait for it to close or refresh the PR.
+
+```bash
+# Dependabot
+gh pr comment <N> --body "$(cat <<'EOF'
+@dependabot rebase
+
+This looks redundant with current `main` (dependency already present or empty merge). Please rebase so Dependabot can close or refresh the PR itself.
+EOF
+)"
+
+# Renovate
+gh pr comment <N> --body "$(cat <<'EOF'
+@renovate rebase
+
+This looks redundant with current `main`. Please rebase so Renovate can close or refresh the PR itself.
+EOF
+)"
+
+# Then wait for bot activity + CI
+gh pr view <N> --json state,statusCheckRollup
+gh pr checks <N>
+```
+
 ## Comments and reviews
 
 ```bash

--- a/.cursor/skills/oldest-pr-merge/gh-recipes.md
+++ b/.cursor/skills/oldest-pr-merge/gh-recipes.md
@@ -3,7 +3,7 @@
 ## Oldest open PR
 
 ```bash
-gh pr list --state open --limit 100 --json number,title,createdAt,url,headRefName \
+gh pr list --state open --limit 100 --json number,title,createdAt,url,headRefName,assignees,labels \
   --jq 'sort_by(.createdAt) | .[0]'
 ```
 
@@ -12,9 +12,45 @@ gh pr list --state open --limit 100 --json number,title,createdAt,url,headRefNam
 ```bash
 gh pr checkout <N>
 gh pr view <N>
+gh pr view <N> --json assignees,labels,title,url
 gh pr diff <N>
 gh pr checks <N>
 ```
+
+## Assignees (required before merge)
+
+Prefer `cursoragent`; fall back to `jimmyandrade` if `cursoragent` is not assignable.
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+if gh api "repos/$REPO/assignees/cursoragent" --silent 2>/dev/null; then
+  gh pr edit <N> --add-assignee cursoragent
+else
+  gh pr edit <N> --add-assignee jimmyandrade
+fi
+
+gh pr view <N> --json assignees --jq '[.assignees[].login]'
+```
+
+Never merge unless `cursoragent` or `jimmyandrade` is assigned.
+
+## Labels (required before merge)
+
+At least **one meaningful** label must exist. Use existing repo labels when possible.
+
+```bash
+gh label list --limit 100
+gh pr view <N> --json labels --jq '[.labels[].name]'
+
+# Examples:
+gh pr edit <N> --add-label "dependencies"   # Renovate / lockfile bumps
+gh pr edit <N> --add-label "documentation"  # docs / skills / AGENTS
+gh pr edit <N> --add-label "bug"            # fixes
+gh pr edit <N> --add-label "enhancement"    # features
+```
+
+Never merge a PR with zero labels.
 
 ## Comments and reviews
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Always use **progressive, atomic commits** (see `CONTRIBUTING.md`):
 - Always **squash merge** PRs: `gh pr merge <N> --squash`.
 - Do not use `--merge` or `--rebase` unless a maintainer explicitly asks for an exception.
 - Prefer an English Conventional Commits subject for the squash commit message.
+- Before merge: assign **`cursoragent`** when assignable, otherwise **`jimmyandrade`**, and ensure **at least one meaningful label**. Never merge without both.
 
 ## Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ Reference related GitHub issues in the subject or footer when applicable (e.g. `
 - Always **squash merge** PRs into the default branch (`gh pr merge <N> --squash`).
 - Do **not** use merge commits (`--merge`) or rebase merges (`--rebase`) unless a maintainer explicitly overrides this for a one-off case.
 - Keep the squash commit message in English and Conventional Commits style when editing it on merge.
+- Before merge: assign **`cursoragent`** when assignable, otherwise **`jimmyandrade`**, and ensure **at least one meaningful label**. Never merge without both.
 
 ## Issues
 


### PR DESCRIPTION
## Summary
- Update `oldest-pr-merge` skill + recipes: assign `cursoragent` (fallback `jimmyandrade`) and require ≥1 meaningful label before any merge
- Mirror the hard gate in `AGENTS.md`, `.cursor/rules/prs.mdc`, and `CONTRIBUTING.md`

## Test plan
- [ ] Read skill §1b / §8 and confirm merge is blocked without assignee + label
- [ ] Confirm `cursoragent` assignability check + `jimmyandrade` fallback is documented

Made with [Cursor](https://cursor.com)