### PR TITLE
fix(deps): bump react monorepo to 17.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,8 @@
         "muy": "1.1.0",
         "prop-types": "15.7.2",
         "query-string": "6.14.1",
-        "react": "17.0.1",
-        "react-dom": "17.0.1",
+        "react": "17.0.2",
+        "react-dom": "17.0.2",
         "react-helmet": "6.1.0",
         "recoil": "0.0.7",
         "use-global-hook": "0.3.0"
@@ -61,7 +61,7 @@
         "jest": "26.6.3",
         "netlify-cli": "2.71.0",
         "prettier": "2.8.8",
-        "react-test-renderer": "17.0.1",
+        "react-test-renderer": "17.0.2",
         "wait-on": "5.3.0"
       },
       "engines": {
@@ -40149,9 +40149,10 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
-      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -40435,16 +40436,17 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
+        "scheduler": "^0.20.2"
       },
       "peerDependencies": {
-        "react": "17.0.1"
+        "react": "17.0.2"
       }
     },
     "node_modules/react-helmet": {
@@ -40542,25 +40544,27 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
-      "integrity": "sha512-/dRae3mj6aObwkjCcxZPlxDFh73XZLgvwhhyON2haZGUEhiaY5EjfAdw+d/rQmlcFwdTpMXCSGVk374QbCTlrA==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "object-assign": "^4.1.1",
-        "react-is": "^17.0.1",
+        "react-is": "^17.0.2",
         "react-shallow-renderer": "^16.13.1",
-        "scheduler": "^0.20.1"
+        "scheduler": "^0.20.2"
       },
       "peerDependencies": {
-        "react": "17.0.1"
+        "react": "17.0.2"
       }
     },
     "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
-      "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
-      "dev": true
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-transition-group": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
     "muy": "1.1.0",
     "prop-types": "15.7.2",
     "query-string": "6.14.1",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "react-helmet": "6.1.0",
     "recoil": "0.0.7",
     "use-global-hook": "0.3.0"
@@ -104,7 +104,7 @@
     "jest": "26.6.3",
     "netlify-cli": "2.71.0",
     "prettier": "2.8.8",
-    "react-test-renderer": "17.0.1",
+    "react-test-renderer": "17.0.2",
     "wait-on": "5.3.0"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- Re-apply the React 17.0.2 monorepo bump from #375, which squash-merged empty after a conflicted sync with \`main\`

## Test plan
- [x] \`npm test\` 28/28
- [ ] CI green

Made with [Cursor](https://cursor.com)