### PR TITLE
ci: apply CodeQL Copilot feedback from #394

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["main"]
   schedule:
     - cron: "56 13 * * 2"
 
@@ -20,22 +20,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ javascript ]
+        language: [javascript]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Follow-up to #394: the squash merge landed the original LGTM workflow (`master`, `checkout@v3`, `codeql-action@v2`).
- Applies Copilot review feedback from #394: target `main`, `actions/checkout@v4`, `github/codeql-action/*@v3`.

## Test plan
- [ ] Confirm workflow file on the PR matches Copilot suggestions
- [ ] After merge, verify CodeQL runs on a push/PR to `main`


Made with [Cursor](https://cursor.com)