### PR TITLE
fix(test): use forwardRef in gatsby Link mock to silence MUI ref warnings

### DIFF
--- a/__mocks__/gatsby.js
+++ b/__mocks__/gatsby.js
@@ -1,26 +1,35 @@
 const React = require("react")
 const gatsby = jest.requireActual("gatsby")
-module.exports = {
-  ...gatsby,
-  graphql: jest.fn(),
-  Link: jest.fn().mockImplementation(
-    // these props are invalid for an `a` tag
-    ({
+
+// MUI Link / ListItem pass a ref into `component`. Production Gatsby Link already
+// uses forwardRef; the Jest mock must too or PropTypes and React warn in tests.
+// @see https://github.com/multei/web/issues/441
+const Link = React.forwardRef(
+  (
+    {
       activeClassName,
       activeStyle,
       getProps,
       innerRef,
       partiallyActive,
-      ref,
       replace,
       to,
       ...rest
-    }) =>
-      React.createElement("a", {
-        ...rest,
-        href: to,
-      })
-  ),
+    },
+    ref
+  ) =>
+    React.createElement("a", {
+      ...rest,
+      href: to,
+      ref,
+    })
+)
+Link.displayName = "GatsbyLink"
+
+module.exports = {
+  ...gatsby,
+  graphql: jest.fn(),
+  Link,
   StaticQuery: jest.fn(),
   useStaticQuery: jest.fn(),
 }

--- a/src/components/Footer/index.test.js
+++ b/src/components/Footer/index.test.js
@@ -1,6 +1,18 @@
 import React from "react"
 import renderer from "react-test-renderer"
+import { render } from "@testing-library/react"
 import Footer from "."
+
+const isFooterLinkRefWarning = (args) =>
+  args.some(
+    (arg) =>
+      typeof arg === "string" &&
+      (arg.includes(
+        "Invalid prop `component` supplied to `ForwardRef(Link)`"
+      ) ||
+        arg.includes("`ref` is not a prop") ||
+        arg.includes("Function components cannot be given refs"))
+  )
 
 describe("Footer", () => {
   it("renders correctly", () => {
@@ -8,5 +20,29 @@ describe("Footer", () => {
       .create(<Footer siteTitle="Test site title" />)
       .toJSON()
     expect(tree).toMatchSnapshot()
+  })
+
+  it("renders help, privacy, and terms links via Gatsby Link without ref warnings", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {})
+
+    const { getByText } = render(<Footer siteTitle="Test site title" />)
+
+    expect(getByText("Ajuda").closest("a")).toHaveAttribute("href", "/ajuda")
+    expect(getByText("Privacidade").closest("a")).toHaveAttribute(
+      "href",
+      "/privacidade"
+    )
+    expect(getByText("Termos de uso").closest("a")).toHaveAttribute(
+      "href",
+      "/termos"
+    )
+
+    const linkRefWarnings = consoleError.mock.calls.filter(
+      isFooterLinkRefWarning
+    )
+    expect(linkRefWarnings).toHaveLength(0)
+    consoleError.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary

- Rewrites the Jest `__mocks__/gatsby.js` `Link` as a `React.forwardRef` component, matching production Gatsby `Link`, and stops destructuring `ref` from props.
- Adds a `Footer` regression test asserting the Ajuda / Privacidade / Termos links render with the right `href` and that the MUI `component` / `ref` console warnings no longer fire.

Closes #441

## Test plan

- [x] `npm test` — 28 suites green, snapshots unchanged
- [x] New regression test fails against the old mock, passes with the fix

Made with [Cursor](https://cursor.com)